### PR TITLE
fix(auth): correct token rotation flow

### DIFF
--- a/client/middleware.ts
+++ b/client/middleware.ts
@@ -3,20 +3,15 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 export function middleware(request: NextRequest) {
-  const token = request.cookies.get('access_token')?.value ?? null;
+  const accessToken = request.cookies.get('access_token')?.value ?? null;
+  const refreshToken = request.cookies.get('refresh_token')?.value ?? null;
   const pathname = request.nextUrl.pathname;
 
-  const PUBLIC_PATHS: string[] = [];
-
-  if (PUBLIC_PATHS.includes(pathname)) {
-    return NextResponse.next();
-  }
-
-  if (token && (pathname === ROUTES.LOGIN || pathname === ROUTES.ROOT)) {
+  if (accessToken && (pathname === ROUTES.LOGIN || pathname === ROUTES.ROOT)) {
     return NextResponse.redirect(new URL(ROUTES.ALL_HOUSES, request.url));
   }
 
-  if (!token && pathname !== ROUTES.LOGIN) {
+  if (!accessToken && !refreshToken && pathname !== ROUTES.LOGIN) {
     return NextResponse.redirect(new URL(ROUTES.LOGIN, request.url));
   }
 

--- a/client/src/shared/components/session-keep-alive.tsx
+++ b/client/src/shared/components/session-keep-alive.tsx
@@ -17,9 +17,7 @@ async function tryRefreshAccessToken(): Promise<void> {
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
   });
-  if (!res.ok) {
-    return;
-  }
+  if (!res.ok) return;
   const data = (await res.json()) as { accessToken?: string };
   if (data.accessToken) {
     tokenStorage.setAccessToken(data.accessToken);
@@ -28,13 +26,12 @@ async function tryRefreshAccessToken(): Promise<void> {
 
 function shouldRefreshSoon(): boolean {
   const token = tokenStorage.getAccessToken();
-  if (!token) {
-    return true;
-  }
+
+  if (!token) return false;
+
   const exp = getJwtExpSeconds(token);
-  if (exp === null) {
-    return false;
-  }
+  if (exp === null) return false;
+
   const secondsLeft = exp - Date.now() / 1000;
   return secondsLeft < REFRESH_THRESHOLD_SEC;
 }
@@ -45,18 +42,14 @@ export function SessionKeepAlive(): null {
   useEffect(() => {
     const run = () => {
       if (isPublicAuthPath(pathname)) return;
-      if (!shouldRefreshSoon()) {
-        return;
-      }
+      if (!shouldRefreshSoon()) return;
       void tryRefreshAccessToken();
     };
 
     run();
     const interval = window.setInterval(run, TICK_MS);
     const onVisibility = () => {
-      if (document.visibilityState === 'visible') {
-        run();
-      }
+      if (document.visibilityState === 'visible') run();
     };
     document.addEventListener('visibilitychange', onVisibility);
     return () => {

--- a/client/src/shared/components/session-keep-alive.tsx
+++ b/client/src/shared/components/session-keep-alive.tsx
@@ -24,10 +24,12 @@ async function tryRefreshAccessToken(): Promise<void> {
   }
 }
 
-function shouldRefreshSoon(): boolean {
+function shouldRefreshSoon(pathname: string): boolean {
   const token = tokenStorage.getAccessToken();
 
-  if (!token) return false;
+  if (!token) {
+    return !isPublicAuthPath(pathname);
+  }
 
   const exp = getJwtExpSeconds(token);
   if (exp === null) return false;
@@ -42,7 +44,7 @@ export function SessionKeepAlive(): null {
   useEffect(() => {
     const run = () => {
       if (isPublicAuthPath(pathname)) return;
-      if (!shouldRefreshSoon()) return;
+      if (!shouldRefreshSoon(pathname)) return;
       void tryRefreshAccessToken();
     };
 

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,26 +1,28 @@
+import KeyvRedis from '@keyv/redis'
+import { CacheModule } from '@nestjs/cache-manager'
 import { Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
-import { TypeOrmModule } from '@nestjs/typeorm'
-import { createDbConfig } from './common/config/db.config'
-import { UsersModule } from './users/users.module'
-import { HousesModule } from './houses/houses.module'
-import { ContractsModule } from './contracts/contracts.module'
-import { RentersModule } from './renters/renters.module'
-import { AuthModule } from './auth/auth.module'
-import { TokensModule } from './tokens/tokens.module'
-import KeyvRedis from '@keyv/redis'
-import { Keyv } from 'keyv'
-import { CacheModule } from '@nestjs/cache-manager'
 import { APP_GUARD } from '@nestjs/core'
-import { JwtAuthGuard } from './auth/guard/jwt-auth.guard'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { Keyv } from 'keyv'
 import { AnalyticsModule } from './analytics/analytics.module'
-import { SearchModule } from './search/search.module'
+import { AuthModule } from './auth/auth.module'
+import { JwtAuthGuard } from './auth/guard/jwt-auth.guard'
+import { createDbConfig } from './common/config/db.config'
+import jwtConfig from './common/config/jwt.config'
+import { ContractsModule } from './contracts/contracts.module'
+import { HousesModule } from './houses/houses.module'
 import { MapModule } from './map/map.module'
+import { RentersModule } from './renters/renters.module'
+import { SearchModule } from './search/search.module'
+import { TokensModule } from './tokens/tokens.module'
+import { UsersModule } from './users/users.module'
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
+      load: [jwtConfig],
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -88,7 +88,7 @@ export class AuthController {
     res.cookie(name, token, {
       httpOnly: true,
       secure: isProduction,
-      sameSite: 'none',
+      sameSite: isProduction ? 'none' : 'lax',
       path: '/',
       maxAge: 30 * 24 * 60 * 60 * 1000,
     })

--- a/server/src/common/config/jwt.config.ts
+++ b/server/src/common/config/jwt.config.ts
@@ -11,8 +11,8 @@ const req = (k: string): string => {
 
 export default registerAs('jwt', () => ({
   accessSecret: req('JWT_SECRET'),
-  accessExp: (process.env.JWT_EXPIRES ?? '1d') as StringValue | number,
+  accessExp: (process.env.JWT_ACCESS_EXP ?? '15m') as StringValue | number,
   refreshSecret: req('JWT_REFRESH_SECRET'),
-  refreshExp: (process.env.JWT_REFRESH_EXPIRES ?? '30d') as StringValue | number,
+  refreshExp: (process.env.JWT_REFRESH_EXP ?? '30d') as StringValue | number,
   refreshCookie: process.env.JWT_REFRESH_COOKIE ?? 'refresh_token',
 }))

--- a/server/src/tokens/tokens.service.ts
+++ b/server/src/tokens/tokens.service.ts
@@ -1,5 +1,5 @@
 import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager'
-import { Inject, Injectable } from '@nestjs/common'
+import { Inject, Injectable, InternalServerErrorException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { JwtService } from '@nestjs/jwt'
 import * as argon2 from 'argon2'
@@ -62,10 +62,11 @@ export class TokensService {
       }),
     ])
 
-    await this.create({ payload, token: refreshToken }).catch((err) =>
-      // eslint-disable-next-line no-console
-      console.error('Failed to store refresh token in Redis', err)
-    )
+    try {
+      await this.create({ payload, token: refreshToken })
+    } catch {
+      throw new InternalServerErrorException('Could not persist session')
+    }
 
     return { accessToken, refreshToken }
   }

--- a/server/src/tokens/tokens.service.ts
+++ b/server/src/tokens/tokens.service.ts
@@ -1,13 +1,13 @@
+import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable } from '@nestjs/common'
-import { JwtService } from '@nestjs/jwt'
 import { ConfigService } from '@nestjs/config'
+import { JwtService } from '@nestjs/jwt'
 import * as argon2 from 'argon2'
 import ms, { StringValue } from 'ms'
 import { JwtPayload } from 'types/jwt/jwt.types'
-import { TokensDto } from './dto/tokens.dto'
 import { CreateRefreshTokenDto } from './dto/create-refresh-token.dto'
-import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager'
 import { RefreshTokenDto } from './dto/refresh-token.dto'
+import { TokensDto } from './dto/tokens.dto'
 
 @Injectable()
 export class TokensService {
@@ -62,7 +62,7 @@ export class TokensService {
       }),
     ])
 
-    this.create({ payload, token: refreshToken }).catch((err) =>
+    await this.create({ payload, token: refreshToken }).catch((err) =>
       // eslint-disable-next-line no-console
       console.error('Failed to store refresh token in Redis', err)
     )


### PR DESCRIPTION
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/ade941ce-887e-4a12-83c4-e0da4a7c640e" />

### fix(auth): correct token rotation flow

**Current behavior logs out user when access token expires.**

* If **access token** expired → request new one via **refresh token**
* If refresh token valid:

  * save new access token
  * retry failed/original request
  * keep user logged in
* If refresh token expired/invalid:

  * logout user
  * clear auth state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable authentication flow and token refresh handling; unauthenticated redirects now follow stricter token checks.
  * Backend now fails fast if refresh-token persistence fails, preventing silent session gaps.

* **Chores**
  * Cookie sameSite behavior adjusts by environment for improved browser compatibility.
  * JWT expirations configured (access: 15m, refresh: 30d) and session keep-alive logic refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->